### PR TITLE
adds inline synthetic loot

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -96,7 +96,8 @@ export function Card(props: CardProps) {
           <div className="flex gap-5 rounded">
             <div className={isSelected ? "w-1/3" : ""}>
               <div className="flex flex-wrap gap-x-3">
-                {project.whatToDo.map(({ content, url }, i) => {
+                {project.whatToDo.map(({ content, url, component }, i) => {
+                  if (component) return component;
                   return (
                     <a
                       target="_blank"

--- a/components/SyntheticLoot.tsx
+++ b/components/SyntheticLoot.tsx
@@ -1,0 +1,25 @@
+import useSyntheticLoot from 'hooks/useSyntheticLoot';
+import { useWalletContext } from 'hooks/useWalletContext';
+import React from 'react';
+
+const SyntheticLoot = () => {
+  const { connectWallet, account } = useWalletContext();
+  const syntheticLootSVG = useSyntheticLoot();
+  console.log({ syntheticLootSVG });
+  return (
+    <div className="synthetic-loot">
+      {!account ? (
+        <button
+          className="bg-gray-800 hover:bg-gray-600 py-2 border-gray-600 border rounded px-4 my-1"
+          onClick={connectWallet}
+        >
+          Connect Wallet to View Your sLoot
+        </button>
+      ) : syntheticLootSVG ? (
+        <svg dangerouslySetInnerHTML={{ __html: syntheticLootSVG }} />
+      ) : null}
+    </div>
+  );
+};
+
+export default SyntheticLoot;

--- a/hooks/useSyntheticLoot.tsx
+++ b/hooks/useSyntheticLoot.tsx
@@ -1,0 +1,48 @@
+import { Contract } from '@ethersproject/contracts';
+import { useEffect, useState } from 'react';
+import { useWalletContext } from './useWalletContext';
+
+const useSyntheticLoot = () => {
+  const { account, provider } = useWalletContext();
+  const [svg, setSVG] = useState<string>();
+  useEffect(() => {
+    if (!account || !provider) return;
+    const contract = new Contract(
+      SyntheticLootMainnetAddress,
+      SyntheticLootPartialABI,
+      provider
+    );
+    contract.functions
+      .tokenURI(account)
+      .then(([tokenURI]: [tokenURI: string]) => {
+        try {
+          const _svg = atob(
+            JSON.parse(
+              atob(tokenURI.replace('data:application/json;base64,', ''))
+            ).image.replace('data:image/svg+xml;base64,', '')
+          );
+          setSVG(_svg);
+        } catch (err) {
+          console.log(err);
+        }
+      });
+  }, [account, provider]);
+  return svg;
+};
+
+const SyntheticLootMainnetAddress =
+  '0x869ad3dfb0f9acb9094ba85228008981be6dbdde';
+
+const SyntheticLootPartialABI = [
+  {
+    inputs: [
+      { internalType: 'address', name: 'walletAddress', type: 'address' }
+    ],
+    name: 'tokenURI',
+    outputs: [{ internalType: 'string', name: '', type: 'string' }],
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+export default useSyntheticLoot;

--- a/types/interface.ts
+++ b/types/interface.ts
@@ -1,37 +1,38 @@
 interface CardDetails {
-    name: String;
-    description: String;
-    project: Array<Project>;
+  name: String;
+  description: String;
+  project: Array<Project>;
 }
 
 interface Project {
-    name: String;
-    heading?: String;
-    description: String;
-    whatToDo: Array<Content>;
-    roadMap?: Content;
-    website?: Content;
-    contract?: Content;
-    twitter?: Content;
-    discord?: Content;
-    opensea?: Content;
-    github?: Content;
-    mintPrice?: Price;
-    image?: String;
-    neededProject?: Project;
-    logo?: String;
+  name: String;
+  heading?: String;
+  description: String;
+  whatToDo: Array<Content>;
+  roadMap?: Content;
+  website?: Content;
+  contract?: Content;
+  twitter?: Content;
+  discord?: Content;
+  opensea?: Content;
+  github?: Content;
+  mintPrice?: Price;
+  image?: String;
+  neededProject?: Project;
+  logo?: String;
 }
 
 interface Content {
-    content?: String,
-    url?: String
+  content?: String,
+  url?: String
+  component?: JSX.Element;
 }
 
 interface Price {
-    mint?: Number
+  mint?: Number
 }
 
 export type {
-    CardDetails,
-    Project
+  CardDetails,
+  Project
 }

--- a/utils/projects.tsx
+++ b/utils/projects.tsx
@@ -1,3 +1,4 @@
+import SyntheticLoot from "@components/SyntheticLoot";
 import { Project } from "../types/interface";
 const loot: Project = {
   name: "Loot (for Adventurers)",
@@ -348,7 +349,7 @@ const sLoot: Project = {
   whatToDo: [
     {
       content: "View your sLoot",
-      url: "https://loot.stephancill.co.za/#/"
+      component: <SyntheticLoot />
     }
   ],
   contract: {


### PR DESCRIPTION
The component on the home page now includes an unstyled inline svg showing the connected wallet's synthetic loot.

https://user-images.githubusercontent.com/573917/136684261-0666b98d-85b5-4037-a5cd-d53b04f3e8f4.mov

